### PR TITLE
APIMGMT-71: Change Rule 138 of section 12 to follow our json-patch standard

### DIFF
--- a/chapters/resources.adoc
+++ b/chapters/resources.adoc
@@ -21,10 +21,18 @@ Body
 
 [source,json]
 ----
-{
-    “completed”: true
-}
+[
+    {
+        "op": "replace",
+        "path": "/completed",
+        "value": true
+    }
+]
 ----
+
+This example uses JSON Patch, where each operation specifies an `op` (operation type such as 
+"replace", "add", "remove"), a `path` (JSON Pointer to the target field), and a `value` (the new value 
+to apply). This format provides a standardized way to express partial updates to resources.
 
 Sometimes, standard HTTP methods aren’t specific enough to indicate the action you wish to perform on a 
 resource, or there is complex business logic on the back end that can’t be satisfied by PATCHing a single 


### PR DESCRIPTION
Change the section 138 of 
[SailPoint RESTful API Guidelines](https://sailpoint-oss.github.io/sailpoint-api-guidelines/#resources)  to include example that follows our json-patch standard. The current example is misleading and was picked from Zalando. We need to update this.

The de-facto standard SP uses for Patch requests is defined in [SailPoint Developer Community](https://developer.sailpoint.com/docs/api/patch-requests) and the same is not explicitly present in our API guidelines. Apart from updating the above example in section 138, possibly explicitly mention about the json-patch standard in the guidelines somewhere.